### PR TITLE
Bump 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tchap-desktop",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "./scripts/index.ts",
   "scripts": {

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -15,33 +15,10 @@ fi
 # Update the version in src-tauri/Cargo.toml
 sed -i 's/version = "'$current_version'"/version = "'$new_version'"/' src-tauri/Cargo.toml
 
+# Update version in tauri.conf.json
+jq '.version = "'"$new_version"'"' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp && mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+
 # Update the version in package.json
 jq '.version = "'"$new_version"'"' package.json > package.json.tmp && mv package.json.tmp package.json
 
 echo "Version updated from $current_version to $new_version"
-
-
-# Update endpoint version  for updater plugin
-CONFIG_FILE="./src-tauri/tauri.conf.json"  # Path to your tauri.conf.json file
-TEMP_FILE="./src-tauri/tauri.conf.json.tmp"
-# Find the download URL for the matching asset
-DOWNLOAD_URL="https://github.com/tchapgouv/tchap-desktop/releases/download/tchap-${new_version}/latest.json" 
-
-echo "Found download URL: $DOWNLOAD_URL"
-
-# Update both the version and endpoints in one jq call
-if jq --arg ver "$new_version" --arg url "$DOWNLOAD_URL" \
-    '.version = $ver | .plugins.updater.endpoints = [$url]' "$CONFIG_FILE" > "$TEMP_FILE"; then
-    if [ -s "$TEMP_FILE" ]; then
-        mv "$TEMP_FILE" "$CONFIG_FILE"
-        echo "Successfully updated version to $new_version and endpoints to $DOWNLOAD_URL in $CONFIG_FILE"
-    else
-        echo "Error: jq produced an empty file"
-        rm "$TEMP_FILE"
-        exit 1
-    fi
-else
-    echo "Error: jq command failed"
-    rm "$TEMP_FILE"
-    exit 1
-fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "tchap-desktop"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "blake2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tchap-desktop"
-version = "0.0.5"
+version = "0.0.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "identifier": "fr.gouv.beta.tchap-desktop",
   "build": {
     "devUrl": "http://localhost:8080",


### PR DESCRIPTION
## Changes
- script update version doesnt update endpoints for updater plugin anymore
- Update to 0.0.6