### PR TITLE
fix: force the usage of tauri.macos.conf file during build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           # it is neceessary for windows to automatically add the dll in the final build
             args: "--config src-tauri\\tauri.conf.windows.prod.json"
           - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
+            args: "--target aarch64-apple-darwin --config src-tauri/tauri.macos.conf.json"
           # TODO : debug because cc linking error for x86_64 mac 
           # - platform: "macos-latest" # for Intel based macs.
           #   args: "--target x86_64-apple-darwin"

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         include:
           - platform: "windows-latest"
-            args: ""
+            args: "--config src-tauri\\tauri.conf.windows.prod.json"
           - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
+            args: "--target aarch64-apple-darwin --config src-tauri/tauri.macos.conf.json"
           # TODO : debug because cc linking error for x86_64 mac 
           # - platform: "macos-latest" # for Intel based macs.
           #   args: "--target x86_64-apple-darwin"


### PR DESCRIPTION
Fix build for macos, it was not taking into account the specific conf for macos