### PR TITLE
Bump 4.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tchap-desktop",
-  "version": "0.0.9",
+  "version": "4.16.1",
   "description": "",
   "main": "./scripts/index.ts",
   "scripts": {
@@ -10,24 +10,24 @@
   "tchapConfig": {
     "use_github": false,
     "prod": {
-      "tchap-web_version": "4.15.2",
-      "tchap-web_archive_name": "tchap-4.15.2-prod-20250701.tar.gz",
+      "tchap-web_version": "4.16.1",
+      "tchap-web_archive_name": "tchap-4.16.1-prod-20250714.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "dev": {
-      "tchap-web_version": "4.15.2",
-      "tchap-web_archive_name": "tchap-4.15.2-dev-20250701.tar.gz",
+      "tchap-web_version": "4.16.1",
+      "tchap-web_archive_name": "tchap-4.16.1-dev-20250714.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "preprod": {
-      "tchap-web_version": "4.15.2",
-      "tchap-web_archive_name": "tchap-4.15.2-preprod-20250701.tar.gz",
+      "tchap-web_version": "4.16.1",
+      "tchap-web_archive_name": "tchap-4.16.1-preprod-20250714.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "tchap-desktop"
-version = "0.0.9"
+version = "4.16.1"
 dependencies = [
  "anyhow",
  "blake2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tchap-desktop"
-version = "0.0.9"
+version = "4.16.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-dev",
-  "version": "0.0.9",
+  "version": "4.16.1",
   "identifier": "fr.gouv.beta.tchap-desktop-dev",
   "build": {
     "devUrl": "http://localhost:8080",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop",
-  "version": "0.0.9",
+  "version": "4.16.1",
   "identifier": "fr.gouv.beta.tchap-desktop",
   "build": {
     "devUrl": "http://localhost:8080",

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-preprod",
-  "version": "0.0.9",
+  "version": "4.16.1",
   "identifier": "fr.gouv.beta.tchap-desktop-preprod",
   "build": {
     "devUrl": "http://localhost:8080",


### PR DESCRIPTION
## Changes
- Match web version 4.16.1 which add desktop notification
- fix mixup between frontend dev/preprod/prod
- remove updater for dev/preprod
- add tray icon menu button