### PR TITLE
Bump 4.16.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tchap-desktop",
-  "version": "4.16.4",
+  "version": "4.16.6",
   "description": "",
   "main": "./scripts/index.ts",
   "scripts": {
@@ -10,24 +10,24 @@
   "tchapConfig": {
     "use_github": false,
     "prod": {
-      "tchap-web_version": "4.16.4",
-      "tchap-web_archive_name": "tchap-4.16.4-prod-20250827.tar.gz",
+      "tchap-web_version": "4.16.6",
+      "tchap-web_archive_name": "tchap-4.16.6-prod-20250908.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "dev": {
-      "tchap-web_version": "4.16.4",
-      "tchap-web_archive_name": "tchap-4.16.4-dev-20250827.tar.gz",
+      "tchap-web_version": "4.16.6",
+      "tchap-web_archive_name": "tchap-4.16.6-dev-20250908.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "preprod": {
-      "tchap-web_version": "4.16.4",
-      "tchap-web_archive_name": "tchap-4.16.4-preprod-20250827.tar.gz",
+      "tchap-web_version": "4.16.6",
+      "tchap-web_archive_name": "tchap-4.16.6-preprod-20250908.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "tchap-desktop"
-version = "4.16.4"
+version = "4.16.6"
 dependencies = [
  "anyhow",
  "blake2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tchap-desktop"
-version = "4.16.4"
+version = "4.16.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-dev",
-  "version": "4.16.4",
+  "version": "4.16.6",
   "identifier": "fr.gouv.beta.tchap-desktop-dev",
   "build": {
     "devUrl": "http://localhost:8080",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop",
-  "version": "4.16.4",
+  "version": "4.16.6",
   "identifier": "fr.gouv.beta.tchap-desktop",
   "build": {
     "devUrl": "http://localhost:8080",
@@ -45,7 +45,9 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": ["tchap"]
+        "schemes": [
+          "tchap"
+        ]
       }
     },
     "protocol": {

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-preprod",
-  "version": "4.16.4",
+  "version": "4.16.6",
   "identifier": "fr.gouv.beta.tchap-desktop-preprod",
   "build": {
     "devUrl": "http://localhost:8080",


### PR DESCRIPTION
## Changes
- Use tchap web 4.16.6 which include SSO open with default browser
- Include element call conf for dinum 