### PR TITLE
Bump 4.17.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tchap-desktop",
-  "version": "4.17.4",
+  "version": "4.17.5",
   "description": "",
   "main": "./scripts/index.ts",
   "scripts": {
@@ -10,24 +10,24 @@
   "tchapConfig": {
     "use_github": false,
     "prod": {
-      "tchap-web_version": "4.17.4",
-      "tchap-web_archive_name": "tchap-4.17.4-prod-20251112.tar.gz",
+      "tchap-web_version": "4.17.5",
+      "tchap-web_archive_name": "tchap-4.17.5-prod-20251119.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "dev": {
-      "tchap-web_version": "4.17.4",
-      "tchap-web_archive_name": "tchap-4.17.4-dev-20251112.tar.gz",
+      "tchap-web_version": "4.17.5",
+      "tchap-web_archive_name": "tchap-4.17.5-dev-20251119.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "preprod": {
-      "tchap-web_version": "4.17.4",
-      "tchap-web_archive_name": "tchap-4.17.4-preprod-20251112.tar.gz",
+      "tchap-web_version": "4.17.5",
+      "tchap-web_archive_name": "tchap-4.17.5-preprod-20251119.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "tchap-desktop"
-version = "4.17.4"
+version = "4.17.5"
 dependencies = [
  "anyhow",
  "blake2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tchap-desktop"
-version = "4.17.4"
+version = "4.17.5"
 description = "Desktop app of tchap web."
 edition = "2024"
 

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-dev",
-  "version": "4.17.4",
+  "version": "4.17.5",
   "identifier": "fr.gouv.beta.tchap-desktop-dev",
   "build": {
     "devUrl": "http://localhost:8088",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tchap",
-  "version": "4.17.4",
+  "version": "4.17.5",
   "identifier": "fr.gouv.beta.tchap-desktop",
   "build": {
     "devUrl": "http://localhost:8088",

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-preprod",
-  "version": "4.17.4",
+  "version": "4.17.5",
   "identifier": "fr.gouv.beta.tchap-desktop-preprod",
   "build": {
     "devUrl": "http://localhost:8080",


### PR DESCRIPTION
- align to tchap-web 4.17.5 . Only UI hotfix from version 4.17.4