### PR TITLE
Disable tauri native system dragndrop

### DIFF
--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -11,6 +11,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
+        "dragDropEnabled": false,
         "title": "Tchap dev",
         "width": 1000,
         "height": 800,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
+        "dragDropEnabled": false,
         "userAgent": "tchap-linux",
         "title": "Tchap",
         "width": 1000,

--- a/src-tauri/tauri.conf.noupdater.json
+++ b/src-tauri/tauri.conf.noupdater.json
@@ -10,7 +10,8 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "userAgent": "tchap-linux",
+        "dragDropEnabled": false,
+        "userAgent": "tchap-windows",
         "title": "Tchap",
         "width": 1000,
         "height": 800,

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -11,6 +11,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
+        "dragDropEnabled": false,
         "title": "Tchap preprod",
         "width": 1000,
         "height": 800,

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -2,6 +2,7 @@
   "app": {
     "windows": [
       {
+        "dragDropEnabled": false,
         "userAgent": "tchap-macos",
         "title": "Tchap",
         "width": 1000,

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -2,6 +2,7 @@
   "app": {
     "windows": [
       {
+        "dragDropEnabled": false,
         "userAgent": "tchap-windows",
         "title": "Tchap",
         "width": 1000,


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-desktop/issues/112

By default the DOM drag and drop behavior is disabled to use tauri system dragand drop system.
The DOM drag and drop is the one taking care by tchap web, so we disable tauri.
The tauri documentation and defaut behavior about this is still wip : https://github.com/tauri-apps/tauri/issues/14373