### PR TITLE
Go back to nsis currentUser install to not have admin privileges by default

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
     "windows": {
       "allowDowngrades": true,
       "nsis": {
-        "installMode": "both"
+        "installMode": "currentUser"
       },
       "wix": {
         "language": "fr-FR"

--- a/src-tauri/tauri.conf.noupdater.json
+++ b/src-tauri/tauri.conf.noupdater.json
@@ -27,7 +27,7 @@
     "windows": {
       "allowDowngrades": true,
       "nsis": {
-        "installMode": "both"
+        "installMode": "currentUser"
       },
       "wix": {
         "language": "fr-FR"


### PR DESCRIPTION
- When configuring nsis to have both install mode (permachine and curerntUser), it will select by default permachine, which will ask user admin privileges
We want the application to install by default in current user directory and not have access to admin privileges, so it is preferable to go back to currentUser install mode only