### PR TITLE
Change no updater product name and release

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -132,7 +132,7 @@ jobs:
 # Uploading the tauri app to a release
       - name: create Tauri app artifacts
         if: inputs.platform != 'ubuntu-22.04'
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -140,12 +140,11 @@ jobs:
         with:
           releaseId: ${{ inputs.releaseId }}
           args: ${{ inputs.args }}
-          includeDebug: false
-          updaterJsonKeepUniversal: true
+          uploadWorkflowArtifacts: true
  
       - name: create Tauri app for linux
         if: inputs.platform == 'ubuntu-22.04'
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -154,12 +153,18 @@ jobs:
         with:
           releaseId: ${{ inputs.releaseId }}
           args: ${{ inputs.args }}
-          includeDebug: true
-          updaterJsonKeepUniversal: true
       
+      - name: Create release asset name pattern for no updater version
+        id: create-pattern-no-updater
+        run: |
+          PATTERN="[name]-[version]_[arch]_${{ inputs.env }}_no_updater[ext]"
+          echo "PATTERN=$PATTERN" >> $GITHUB_OUTPUT
+          echo "Generated pattern: $PATTERN"
+        shell: bash
+
       - name: create Windows app without updater
         if: inputs.platform == 'windows-latest'
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -167,20 +172,22 @@ jobs:
         with:
           releaseId: ${{ inputs.releaseId }}
           args: --target x86_64-pc-windows-msvc --config src-tauri/tauri.conf.noupdater-windows.json --features no-updater
-          includeDebug: false
+          releaseAssetNamePattern: ${{ steps.create-pattern-no-updater.outputs.PATTERN }}
+          uploadWorkflowArtifacts: true
+          workflowArtifactNamePattern: ${{ steps.create-pattern-no-updater.outputs.PATTERN }}
 
 # Uploading the tauri app only as artifcats and not release 
-      - name: List build output
-        run: |
-          echo "Listing src-tauri/target/release structure:"
-          ls -R src-tauri/target/ || true
-        shell: bash
+      # - name: List build output
+      #   run: |
+      #     echo "Listing src-tauri/target/release structure:"
+      #     ls -R src-tauri/target/ || true
+      #   shell: bash
 
-      - name: Upload artifacts for windows
-        if: inputs.onPR == true && inputs.platform == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: tauri-app-${{ inputs.platform }}
-          path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/
-          if-no-files-found: warn
-          retention-days: 7
+      # - name: Upload artifacts for windows
+      #   if: inputs.onPR == true && inputs.platform == 'windows-latest'
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: tauri-app-${{ inputs.platform }}
+      #     path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/
+      #     if-no-files-found: warn
+      #     retention-days: 7

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,15 +151,14 @@ pub fn run() {
                 .build(app)?;
 
             // Manually build windows, because on_download listenner can only be added on the build of the windows
-            // Needs to remove app: {windows } from tauri conf, otherwise there will be two window creation
             let product_name = match app.config().product_name.as_deref() {
-                Some("tchap_no_updater") => "Tchap".to_string(),
                 Some(other) => other.to_string(),
                 None => "Tchap".to_string(), // fallback if missing
               };
 
             let handle = app.app_handle().clone();
             let handle_for_on_download = app.app_handle().clone();
+            // Needs to remove app: {windows } from tauri conf, otherwise there will be two window creation
             WebviewWindowBuilder::new(&handle, "main", WebviewUrl::App("index.html".into()))
                 .on_download(move |_webview, event| {
                     if let DownloadEvent::Finished { url, path, success } = event {

--- a/src-tauri/tauri.conf.noupdater-windows.json
+++ b/src-tauri/tauri.conf.noupdater-windows.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "tchap_no_updater",
+  "productName": "Tchap",
   "version": "4.18.3",
-  "identifier": "fr.gouv.beta.tchap-desktop",
+  "identifier": "fr.gouv.beta.tchap-desktop-no-updater",
   "build": {
     "frontendDist": "../src"
   },


### PR DESCRIPTION
fix no updater release artificat, where the last env generateed artifact will crush the others
(tauri-action v1 is still unreleased, directly using dev branch because using tag version not working to get latest v0 version )