### PR TITLE
CI: remove updater json info from release for no updater version

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -175,6 +175,7 @@ jobs:
           releaseAssetNamePattern: ${{ steps.create-pattern-no-updater.outputs.PATTERN }}
           uploadWorkflowArtifacts: true
           workflowArtifactNamePattern: ${{ steps.create-pattern-no-updater.outputs.PATTERN }}
+          uploadUpdaterJson: false
 
 # Uploading the tauri app only as artifcats and not release 
       # - name: List build output


### PR DESCRIPTION
The no-updater version should not appear or overide the updater version