### PR TITLE
fix: Add missing MacOS camera permission

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSCameraUsageDescription</key>
+    <string>This app requires camera access for video calls.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app requires microphone access to record audio.</string>
     <key>NSScreenCaptureUsageDescription</key>


### PR DESCRIPTION
Fixes #113

On macOS, video calls were not working because the `NSCameraUsageDescription` permission was missing.

This PR adds the required permission to `Info.plist`.