### PR TITLE
Desktop update improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tchap-desktop",
-  "version": "4.18.4",
+  "version": "4.18.2",
   "description": "",
   "main": "./scripts/index.ts",
   "scripts": {
@@ -8,7 +8,7 @@
     "update-version": "./scripts/update-version.sh"
   },
   "tchapConfig": {
-    "use_github": false,
+    "use_github": true,
     "prod": {
       "tchap-web_version": "4.18.4",
       "tchap-web_archive_name": "tchap-4.18.4-prod-20260120.tar.gz",
@@ -21,7 +21,7 @@
       "tchap-web_version": "4.18.4",
       "tchap-web_archive_name": "tchap-4.18.4-dev-20260120.tar.gz",
       "tchap-web_github": {
-        "branch": "develop_tchap",
+        "branch": "desktop-automatic-update-improvements",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "tchap-desktop"
-version = "4.18.4"
+version = "4.18.3"
 dependencies = [
  "anyhow",
  "blake2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tchap-desktop"
-version = "4.18.4"
+version = "4.18.2"
 description = "Desktop app of tchap web."
 edition = "2024"
 

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-dev",
-  "version": "4.18.4",
+  "version": "4.18.2",
   "identifier": "fr.gouv.beta.tchap-desktop-dev",
   "build": {
     "devUrl": "http://localhost:8088",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tchap",
-  "version": "4.18.4",
+  "version": "4.18.2",
   "identifier": "fr.gouv.beta.tchap-desktop",
   "build": {
     "devUrl": "http://localhost:8088",

--- a/src-tauri/tauri.conf.noupdater-windows.json
+++ b/src-tauri/tauri.conf.noupdater-windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tchap",
-  "version": "4.18.4",
+  "version": "4.18.2",
   "identifier": "fr.gouv.beta.tchap-desktop-no-updater",
   "build": {
     "frontendDist": "../src"

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-preprod",
-  "version": "4.18.4",
+  "version": "4.18.2",
   "identifier": "fr.gouv.beta.tchap-desktop-preprod",
   "build": {
     "devUrl": "http://localhost:8080",


### PR DESCRIPTION
**Only a testing branch for the auto update. All code change is done on the web side** 

Linked to https://github.com/tchapgouv/tchap-web-v4/pull/1503 for automatic update improvements


- Check update every hour in app
- Show loader during download and close app for install
- Give user ability to refuse update, it will only be prompted about it 3 days after

Using version 4.18.2 for testing purpose since latest version is 4.18.3 in dev