### PR TITLE
macOs: show/hide window when clicking on the docker app icon

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,22 @@ pub fn run() {
             keyring_commands::delete_password,
             welcome
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app, event| match event {
+            //show/hide window on click on the docker app icon (RunEvent::Reopen is only for macOs)
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { has_visible_windows , .. } => {
+                if let Some(webview_window) = _app.get_webview_window("main") {
+                    if has_visible_windows {
+                       webview_window.hide().unwrap();
+                   } else {
+                       let _ = webview_window.unminimize();
+                       let _ = webview_window.set_focus();
+                       let _ = webview_window.show();
+                   }
+                }
+            }
+            _ => {}
+        });
 }


### PR DESCRIPTION
when clicking on docker icon, it opens the window

<img width="131" height="106" alt="image" src="https://github.com/user-attachments/assets/64a91965-4c9d-4c8d-9771-a6fd08833134" />
