### PR TITLE
Modify wix to be perUser install scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ A `TauriPlatform` has been created in tchap-web (which is a soft fork of [elemen
 
 - Install Node and npm using a version manager like nvm. The frontend required a node version = 20.
 
-## For windows admin
+## For windows installation
 Two different type of builds are proposed : 
-- With no updater : the admin of the fleets will have the burden 
+- With no updater : the admin of the fleets will have the burden to push new version of the app
 - With auto updates: updates will be pushed automatically to users by Tchap team
 
-The .msi installer is perUser only whereas the .exe is both (will take perMachine mode by default so will ask admin privileges to install).
+The .msi installer which include the auto-update is perUser only whereas the .exe is both (will take perMachine mode by default so will ask admin privileges to install). Whereas the .msi installer with no updater is perMachine, it will require admin rights to install the app
 
 
 ## Dev local using local frontend

--- a/src-tauri/resources/windows/config.wxs
+++ b/src-tauri/resources/windows/config.wxs
@@ -36,6 +36,7 @@
         <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
         <Property Id="REINSTALLMODE" Value="amus" />
         <!-- :TCHAP: dual purpose install https://learn.microsoft.com/en-us/windows/win32/msi/msiinstallperuser -->
+        <!-- This is actually a hack because setting applocal as install dir is not working (light.exe error) -->
         <Property Id="ALLUSERS" Secure="yes" Value="2"/>
         <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1" />
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,16 +14,6 @@
     }
   },
   "bundle": {
-    "windows": {
-      "allowDowngrades": true,
-      "nsis": {
-        "installMode": "currentUser"
-      },
-      "wix": {
-        "language": "fr-FR",
-        "template": "./resources/windows/config.wxs"
-      }
-    },
     "active": true,
     "targets": "all",
     "icon": [

--- a/src-tauri/tauri.conf.noupdater-windows.json
+++ b/src-tauri/tauri.conf.noupdater-windows.json
@@ -16,21 +16,13 @@
     "windows": {
       "allowDowngrades": true,
       "nsis": {
-        "installMode": "currentUser"
+        "installMode": "both"
       },
       "wix": {
-        "language": "fr-FR"
+        "language": "fr-FR",
+        "template": null
       }
     },
-    "active": true,
-    "targets": "all",
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ],
     "createUpdaterArtifacts": false,
     "resources": {
       "resources/windows/msvcp140.dll": "./msvcp140.dll",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -3,21 +3,13 @@
     "windows": {
       "allowDowngrades": true,
       "nsis": {
-        "installMode": "currentUser"
+        "installMode": "both"
       },
       "wix": {
-        "language": "fr-FR"
+        "language": "fr-FR",
+        "template": "./resources/windows/config.wxs"
       }
     },
-    "active": true,
-    "targets": "all",
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ],
     "resources": {
       "resources/windows/msvcp140.dll": "./msvcp140.dll",
       "resources/windows/vcruntime140.dll": "./vcruntime140.dll"


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-desktop/pull/180
closes https://github.com/tchapgouv/tchap-desktop/issues/148

## Changes 
- Per defaut the installation for the msi installer was perMachine which require admin privileges
- This create a new wix template based on [tauri's](https://github.com/tauri-apps/tauri/blob/dev/crates/tauri-bundler/src/bundle/windows/msi/main.wxs) to use installScope perUser