### PR TITLE
Reput win bundle config in initial tauri conf

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,10 +51,8 @@ jobs:
           # this config will be merge with tauri.windows.conf.json automatically. Same system for other platform
           # it is neceessary for windows to automatically add the dll in the final build
             args: "--target x86_64-pc-windows-msvc"
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
-          - platform: "macos-latest" # for Intel based macs.
-            args: "--target x86_64-apple-darwin"
+          - platform: "macos-latest" # for Arm based macs (M1 and above) and Intel based macs.
+            args: "--target universal-apple-darwin"
           - platform: "ubuntu-22.04"
             args: "--target x86_64-unknown-linux-gnu"
     uses: ./.github/workflows/build-tauri.yml
@@ -80,10 +78,8 @@ jobs:
           # this config will be merge with tauri.conf.json,
           # Needs to explicitly set tauri conf for dev build to overide name and identifier,
             args: "--target x86_64-pc-windows-msvc --config src-tauri\\tauri.conf.dev.json"
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin --config src-tauri/tauri.conf.dev.json"
-          - platform: "macos-latest" # for Intel based macs.
-            args: "--target x86_64-apple-darwin --config src-tauri/tauri.conf.dev.json"
+          - platform: "macos-latest" # for Arm based macs (M1 and above) and Intel based macs.
+            args: "--target universal-apple-darwin --config src-tauri/tauri.conf.dev.json"
           - platform: "ubuntu-22.04"
             args: "--target x86_64-unknown-linux-gnu --config src-tauri/tauri.conf.dev.json"
     uses: ./.github/workflows/build-tauri.yml
@@ -109,9 +105,7 @@ jobs:
           # Needs to explicitly set tauri conf for preprod build to overide name and identifier
             args: "--target x86_64-pc-windows-msvc --config src-tauri\\tauri.conf.preprod.json"
           - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin --config src-tauri/tauri.conf.preprod.json"
-          - platform: "macos-latest" # for Intel based macs.
-            args: "--target x86_64-apple-darwin --config src-tauri/tauri.conf.preprod.json"
+            args: "--target universal-apple-darwin --config src-tauri/tauri.conf.preprod.json"
           - platform: "ubuntu-22.04"
             args: "--target x86_64-unknown-linux-gnu --config src-tauri/tauri.conf.preprod.json"
     uses: ./.github/workflows/build-tauri.yml

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,20 @@
     }
   },
   "bundle": {
+    "windows": {
+      "allowDowngrades": true,
+      "nsis": {
+        "installMode": "both"
+      },
+      "wix": {
+        "language": "fr-FR",
+        "template": "./resources/windows/config.wxs"
+      }
+    },
+    "resources": {
+      "resources/windows/msvcp140.dll": "./msvcp140.dll",
+      "resources/windows/vcruntime140.dll": "./vcruntime140.dll"
+    },
     "active": true,
     "targets": "all",
     "icon": [
@@ -38,15 +52,11 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": [
-          "tchap"
-        ]
+        "schemes": ["tchap"]
       }
     },
     "protocol": {
-      "schemas": [
-        "tchap"
-      ]
+      "schemas": ["tchap"]
     }
   }
 }


### PR DESCRIPTION
Looks like the merge with tauri.win conf is not working well
- Update macos to universal build in publish 