### PR TITLE
Change open file downloaded to display modal from tauri

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "update-version": "./scripts/update-version.sh"
   },
   "tchapConfig": {
-    "use_github": false,
     "prod": {
+      "use_github": false,
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-prod-20260409.tar.gz",
       "tchap-web_github": {
@@ -18,18 +18,20 @@
       }
     },
     "dev": {
+      "use_github": true,
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-dev-20260409.tar.gz",
       "tchap-web_github": {
-        "branch": "develop_tchap",
+        "branch": "desktop-fix-file-opener-security-issue",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "preprod": {
+      "use_github": false,
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-preprod-20260409.tar.gz",
       "tchap-web_github": {
-        "branch": "develop_tchap",
+        "branch": "desktop-fix-file-opener-security-issue",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-dev-20260409.tar.gz",
       "tchap-web_github": {
-        "branch": "desktop-fix-file-opener-security-issue",
+        "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
@@ -31,7 +31,7 @@
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-preprod-20260409.tar.gz",
       "tchap-web_github": {
-        "branch": "desktop-fix-file-opener-security-issue",
+        "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     }

--- a/scripts/fetch-package.ts
+++ b/scripts/fetch-package.ts
@@ -10,15 +10,16 @@ import { exec as execCallback, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
 interface TchapConfig {
-  use_github: boolean;
   prod: TchapConfigEnv;
   dev: TchapConfigEnv;
+  preprod: TchapConfigEnv;
 }
 
 interface TchapConfigEnv {
   "tchap-web_version": string;
   "tchap-web_archive_name": string;
-  "tchap-web_github": { branch: string; repo: string; };
+  "tchap-web_github": { branch: string; repo: string };
+  "use_github": boolean;
 }
 
 const config: TchapConfig = tchapConfig as TchapConfig;
@@ -185,16 +186,18 @@ async function buildFromArchive(targetVersion: string, filename: string) {
 
 async function main(): Promise<number | undefined> {
 
-    if (config.use_github) {
+    if (config[TCHAP_ENV].use_github) {
       await buildFromGithubRepo(
         (config[TCHAP_ENV] as TchapConfigEnv)["tchap-web_github"].repo,
-        (config[TCHAP_ENV] as TchapConfigEnv)["tchap-web_github"].branch
+        (config[TCHAP_ENV] as TchapConfigEnv)["tchap-web_github"].branch,
       );
     } else {
-      const targetVersion: string | undefined =
-        (config[TCHAP_ENV] as TchapConfigEnv)["tchap-web_version"];
-      const filename: string | undefined =
-        (config[TCHAP_ENV] as TchapConfigEnv)["tchap-web_archive_name"];
+      const targetVersion: string | undefined = (
+        config[TCHAP_ENV] as TchapConfigEnv
+      )["tchap-web_version"];
+      const filename: string | undefined = (
+        config[TCHAP_ENV] as TchapConfigEnv
+      )["tchap-web_archive_name"];
       await buildFromArchive(targetVersion, filename);
     }
     console.log("Done!");

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,7 +8,6 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "opener:allow-reveal-item-in-dir",
     "upload:default",
     "core:path:default",
     "core:event:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "opener:allow-reveal-item-in-dir",
     "upload:default",
     "core:path:default",
     "core:event:default",

--- a/src-tauri/src/common_commands.rs
+++ b/src-tauri/src/common_commands.rs
@@ -25,14 +25,14 @@ pub async fn clear_storage<R: Runtime>(app_handle: AppHandle<R>) -> Result<(), S
     app_handle.restart()
 }
 
-// Called when a download is finished, the user can ignore the toast or open the downloaded file
+// Called when a download is finished, the user can ignore the toast or reveal the downloaded file in the default explorer
 #[tauri::command]
 pub async fn user_download_action<R: Runtime>(
     app_handle: AppHandle<R>,
     path: String,
 ) -> Result<(), CommonError> {
     println!("in command user download action {:?}", path);
-    let _ = app_handle.opener().open_path(path, None::<&str>);
+    let _ = app_handle.opener().reveal_item_in_dir(path);
     Ok(())
 }
 

--- a/src-tauri/src/common_commands.rs
+++ b/src-tauri/src/common_commands.rs
@@ -26,14 +26,13 @@ pub async fn clear_storage<R: Runtime>(app_handle: AppHandle<R>) -> Result<(), S
     app_handle.restart()
 }
 
-// Called when a download is finished, the user can ignore the toast or reveal the downloaded file in the default explorer
+// Called when a download is finished, the user can ignore the modal or accept and open the file
 #[tauri::command]
 pub async fn user_download_action<R: Runtime>(
     app_handle: AppHandle<R>,
     path: String,
 ) -> Result<(), CommonError> {
     println!("in command user download action {:?}", path);
-    // let _ = app_handle.opener().open_path(path, None::<&str>);
     let message = format!("Voulez vous ouvrir le fichier {path} ?");
 
     app_handle.dialog()

--- a/src-tauri/src/common_commands.rs
+++ b/src-tauri/src/common_commands.rs
@@ -2,6 +2,7 @@ use std::fs;
 use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_opener::OpenerExt;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
 use crate::common_error::CommonError;
 
@@ -32,7 +33,21 @@ pub async fn user_download_action<R: Runtime>(
     path: String,
 ) -> Result<(), CommonError> {
     println!("in command user download action {:?}", path);
-    let _ = app_handle.opener().reveal_item_in_dir(path);
+    // let _ = app_handle.opener().open_path(path, None::<&str>);
+    let message = format!("Voulez vous ouvrir le fichier {path} ?");
+
+    app_handle.dialog()
+        .message(message)
+        .kind(MessageDialogKind::Info)
+        .title("Téléchargement réussi")
+        .buttons(MessageDialogButtons::YesNo)
+        .show(move |result| match result {
+            true => {
+                println!("in command user download action true");
+                let _ = app_handle.opener().open_path(path, None::<&str>);
+            },
+            false => println!("in command user download action false"),
+        });
     Ok(())
 }
 


### PR DESCRIPTION
Web PR https://github.com/tchapgouv/tchap-web-v4/pull/1574

<img width="862" height="700" alt="image" src="https://github.com/user-attachments/assets/833fd644-b6c9-4178-bab0-cd25e550dffc" />

- Display a modal to ask if user wants to open the file or not. 

So now the action to open the file is linked to the modale opening. It is not possible to execute the opening function anymore without the user being warned with a modal