### PR TITLE
Feat/custom deep link by env

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-dev-20260409.tar.gz",
       "tchap-web_github": {
-        "branch": "feat/custom_deep_link_by_env",
+        "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "update-version": "./scripts/update-version.sh"
   },
   "tchapConfig": {
-    "use_github": false,
+    "use_github": true,
     "prod": {
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-prod-20260409.tar.gz",
@@ -21,7 +21,7 @@
       "tchap-web_version": "4.19.4",
       "tchap-web_archive_name": "tchap-4.19.4-dev-20260409.tar.gz",
       "tchap-web_github": {
-        "branch": "develop_tchap",
+        "branch": "feat/custom_deep_link_by_env",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,18 +74,6 @@ pub fn run() {
             Some(vec!["--flag1", "--flag2"]),
         ))
         .setup(|app| {
-            // commenting this part because it seems to be redundant with the conf in the plugin
-            //  "deep-link": { "desktop": { "schemes": ["tchap" ...
-            /*
-            // Removing deeplink registration on macos for now, since it's not working and throwing an error on build
-            // https://github.com/tchapgouv/tchap-desktop/issues/44
-            #[cfg(all(desktop, not(target_os = "macos")))]
-            {
-                use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register("tchap")?;                 
-            }
-            */
-
             // Create the initial state
             let initial_state = MyState { database: None };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,14 +74,17 @@ pub fn run() {
             Some(vec!["--flag1", "--flag2"]),
         ))
         .setup(|app| {
+            // commenting this part because it seems to be redundant with the conf in the plugin
+            //  "deep-link": { "desktop": { "schemes": ["tchap" ...
+            /*
             // Removing deeplink registration on macos for now, since it's not working and throwing an error on build
             // https://github.com/tchapgouv/tchap-desktop/issues/44
             #[cfg(all(desktop, not(target_os = "macos")))]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register("tchap")?; 
-                //TODO should use the value from tauri.conf
+                app.deep_link().register("tchap")?;                 
             }
+            */
 
             // Create the initial state
             let initial_state = MyState { database: None };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,7 +79,8 @@ pub fn run() {
             #[cfg(all(desktop, not(target_os = "macos")))]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
-                app.deep_link().register("tchap")?;
+                app.deep_link().register("tchap")?; 
+                //TODO should use the value from tauri.conf
             }
 
             // Create the initial state

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -27,10 +27,12 @@
         "installMode": "passive"
       }
     },
-    "protocol": {
-      "schemas": [
-        "tchap"
-      ]
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "tchap-dev"
+        ]
+      }
     }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,11 +60,6 @@
           "tchap"
         ]
       }
-    },
-    "protocol": {
-      "schemas": [
-        "tchap"
-      ]
     }
   }
 }

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -4,7 +4,7 @@
   "version": "4.19.4",
   "identifier": "fr.gouv.beta.tchap-desktop-preprod",
   "build": {
-    "devUrl": "http://localhost:8080",
+    "devUrl": "http://localhost:8088",
     "frontendDist": "../src"
   },
   "app": {
@@ -27,10 +27,12 @@
         "installMode": "passive"
       }
     },
-    "protocol": {
-      "schemas": [
-        "tchap"
-      ]
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "tchap-preprod"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
- add ability to customize deep link by environment so you can have a dev app and a prod app installed at the same time

needs https://github.com/tchapgouv/tchap-web-v4/pull/1571

TODO : 
- [ ] update policy in preprod for new scheme "tchap-preprod"

Tested : 
- [x] windows 
- [x] mac
- [x] dev
- [x] preprod
- [x] prod
