### PR TITLE
Bump to 4.21.1

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -61,7 +61,7 @@ jobs:
           path: src/
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ inputs.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tchap-desktop",
-  "version": "4.20.0",
+  "version": "4.21.1",
   "description": "",
   "main": "./scripts/index.ts",
   "scripts": {
@@ -9,27 +9,24 @@
   },
   "tchapConfig": {
     "prod": {
-      "use_github": false,
-      "tchap-web_version": "4.20.0",
-      "tchap-web_archive_name": "tchap-4.20.0-prod-20260625.tar.gz",
+      "tchap-web_version": "4.21.1",
+      "tchap-web_archive_name": "tchap-4.21.1-prod-20260722.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "dev": {
-      "use_github": true,
-      "tchap-web_version": "4.20.0",
-      "tchap-web_archive_name": "tchap-4.20.0-dev-20260625.tar.gz",
+      "tchap-web_version": "4.21.1",
+      "tchap-web_archive_name": "tchap-4.21.1-dev-20260722.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"
       }
     },
     "preprod": {
-      "use_github": true,
-      "tchap-web_version": "4.20.0",
-      "tchap-web_archive_name": "tchap-4.20.0-preprod-20260625.tar.gz",
+      "tchap-web_version": "4.21.1",
+      "tchap-web_archive_name": "tchap-4.21.1-preprod-20260722.tar.gz",
       "tchap-web_github": {
         "branch": "develop_tchap",
         "repo": "https://github.com/tchapgouv/tchap-web-v4"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "tchap-desktop"
-version = "4.20.0"
+version = "4.21.1"
 dependencies = [
  "anyhow",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tchap-desktop"
-version = "4.20.0"
+version = "4.21.1"
 description = "Desktop app of tchap web."
 edition = "2024"
 

--- a/src-tauri/tauri.conf.dev.json
+++ b/src-tauri/tauri.conf.dev.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-dev",
-  "version": "4.20.0",
+  "version": "4.21.1",
   "identifier": "fr.gouv.beta.tchap-desktop-dev",
   "build": {
     "devUrl": "http://localhost:8088",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tchap",
-  "version": "4.20.0",
+  "version": "4.21.1",
   "identifier": "fr.gouv.beta.tchap-desktop",
   "build": {
     "devUrl": "http://localhost:8088",

--- a/src-tauri/tauri.conf.noupdater-windows.json
+++ b/src-tauri/tauri.conf.noupdater-windows.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tchap",
-  "version": "4.20.0",
+  "version": "4.21.1",
   "identifier": "fr.gouv.beta.tchap-desktop-no-updater",
   "build": {
     "frontendDist": "../src"

--- a/src-tauri/tauri.conf.preprod.json
+++ b/src-tauri/tauri.conf.preprod.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tchap-desktop-preprod",
-  "version": "4.20.0",
+  "version": "4.21.1",
   "identifier": "fr.gouv.beta.tchap-desktop-preprod",
   "build": {
     "devUrl": "http://localhost:8088",


### PR DESCRIPTION
[fix rust to 1.96.0](https://github.com/tchapgouv/tchap-desktop/pull/235/commits/75aea6311418bbf6725d2ae31156d0f6e99f1717) -> to avoid new version of clippy complaining about seshat 